### PR TITLE
:heavy_check_mark: fixed special case !lst

### DIFF
--- a/ft_lstclear.c
+++ b/ft_lstclear.c
@@ -6,7 +6,7 @@
 /*   By: sshakya <marvin@42.fr>                     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/11/26 02:01:38 by sshakya           #+#    #+#             */
-/*   Updated: 2020/11/28 06:14:26 by sshakya          ###   ########.fr       */
+/*   Updated: 2020/11/30 15:20:22 by sshakya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,8 @@ void	ft_lstclear(t_list **lst, void (*del)(void *))
 	t_list	*temp;
 	t_list	*next;
 
+	if (!lst)
+		return ;
 	temp = *lst;
 	while (temp != NULL)
 	{


### PR DESCRIPTION
*

*
when you are past a **lst as a function parameter you need to add
a check to make sure that the lst exists in case the user uses the
function without entering a **lst.

you can also write this code without a t_list *temp

in that case you will write :
```
t_list *next;
while (lst && next != NULL){
next = (*lst)->next;
ft_lstdelone(*lst, dest);
*lst = next;
}
```