### PR TITLE
:heavy_check_mark: Fixed wrong malloc size

### DIFF
--- a/ft_substr.c
+++ b/ft_substr.c
@@ -6,7 +6,7 @@
 /*   By: sshakya <marvin@42.fr>                     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/11/21 16:33:51 by sshakya           #+#    #+#             */
-/*   Updated: 2020/11/25 03:28:09 by sshakya          ###   ########.fr       */
+/*   Updated: 2020/11/30 15:54:06 by sshakya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,8 +20,8 @@ char	*ft_substr(char const *s, unsigned int start, size_t len)
 		return (NULL);
 	if (ft_strlen(s) < start)
 		return (ft_strdup(""));
-	if (!(sub = malloc(sizeof(char) * (len + 1))))
+	if (!(sub = malloc(sizeof(char) * ((len - start) + 1))))
 		return (NULL);
-	ft_strlcpy(sub, s + start, len + 1);
+	ft_strlcpy(sub, s + start, (len - start) + 1);
 	return (sub);
 }


### PR DESCRIPTION
*

*
Since the return string is of size len - start
added len start to the malloc call and to the call to my
ft_strlcpy function.