### PR TITLE
:heavy_check_mark: Finally split is fixed

### DIFF
--- a/ft_split.c
+++ b/ft_split.c
@@ -6,25 +6,40 @@
 /*   By: sshakya <marvin@42.fr>                     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/11/23 14:58:39 by sshakya           #+#    #+#             */
-/*   Updated: 2020/12/01 18:31:02 by sshakya          ###   ########.fr       */
+/*   Updated: 2020/12/01 21:22:41 by sshakya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
+static void			*ft_reset(char **tab, size_t n)
+{
+	size_t			i;
+
+	i = 0;
+	while (i < n)
+	{
+		if (tab[i])
+			free(tab[i]);
+	}
+	free(tab[i]);
+	return (NULL);
+}
+
 static size_t		ft_size(char const *str, char c)
 {
 	size_t			size;
+	int				end;
 
 	size = 0;
+	end = 1;
 	if (c == '\0')
 		return (1);
 	while (*str != '\0')
 	{
-		if (*(str + 1) == '\0')
-			return (size + 1);
-		if (*str == c && *(str + 1) != c)
+		if (*str != c && end)
 			size++;
+		end = *str == c;
 		str++;
 	}
 	return (size);
@@ -38,8 +53,6 @@ static char			*ft_set_string(char const *str, size_t len)
 	if (!(ret = malloc(sizeof(char) * (len + 1))))
 		return (NULL);
 	i = 0;
-	if (str[i] == '\0')
-		return (NULL);
 	while (i < len)
 	{
 		ret[i] = str[i];
@@ -71,7 +84,8 @@ char				**ft_split(char const *str, char c)
 			len++;
 			str++;
 		}
-		tab[n] = ft_set_string((str - len), len);
+		if (!(tab[n] = ft_set_string((str - len), len)))
+			return (ft_reset(tab, n));
 		n++;
 	}
 	return (tab);


### PR DESCRIPTION
*

*
the ft_size function was returning the wrong size to malloc and this was
creating a massive problem. Fixed using a "flag" variable which allows to
exclude the count if the end of the string is reached. thx @ttranche