### PR TITLE
:heavy_check_mark: Fixed NULL variable segfault

### DIFF
--- a/ft_split.c
+++ b/ft_split.c
@@ -6,7 +6,7 @@
 /*   By: sshakya <marvin@42.fr>                     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/11/23 14:58:39 by sshakya           #+#    #+#             */
-/*   Updated: 2020/12/01 21:22:41 by sshakya          ###   ########.fr       */
+/*   Updated: 2020/12/02 19:18:15 by sshakya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ static void			*ft_reset(char **tab, size_t n)
 		if (tab[i])
 			free(tab[i]);
 	}
-	free(tab[i]);
+	free(tab);
 	return (NULL);
 }
 

--- a/ft_strnstr.c
+++ b/ft_strnstr.c
@@ -6,7 +6,7 @@
 /*   By: sshakya <marvin@42.fr>                     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/11/20 20:40:34 by sshakya           #+#    #+#             */
-/*   Updated: 2020/11/27 01:35:58 by sshakya          ###   ########.fr       */
+/*   Updated: 2020/12/02 21:33:15 by sshakya          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,9 +19,9 @@ char		*ft_strnstr(const char *s1, const char *s2, size_t len)
 
 	i = 0;
 	j = 0;
-	if (!(ft_strlen(s2)))
+	if (!s2)
 		return ((char *)s1);
-	while (*s1 && i < len)
+	while (s1 && i < len)
 	{
 		if (*s1 == *s2)
 		{


### PR DESCRIPTION
*

*
My function was segfaulting when either s1 or s2 was set to NULL
as the functon would still try and calculate lenght or compare
bytes that did not exist.

Fixed by checking that s1 s2 exist before doing any comparisons !!